### PR TITLE
Feature: Delete Chats

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ To generate your app’s debug and release certificate fingerprints (SHA-1 and S
 |-------------------|-----------------|
 | **Flutter**       | 3.29.2 stable       |
 | **Dart**          | 3.7.2 stable       |
-| **Java**          | 11        |
+| **Java**          | >= 11        |
 | **Android SDK**   | 35           |
 | **targetSdkVersion** | 35          |
 | **minSdkVersion** | 21              |

--- a/README.md
+++ b/README.md
@@ -23,28 +23,12 @@
   <img src="images/Screenshots/screenshot(6).png" width="150" />
 </p>
 
-## 📦 Installation
-```bash
-git clone https://github.com/your-username/talkio.git
-cd talkio
-flutter pub get
-flutter run --dart-define-from-file=env/env.prd.json
-```
-⚠️ Make sure to include your Firebase **google-services.json** in **android/app/**
-and your environment config in **env/env.prd.json.**
-
-## 🧪 Build
-```bash
-flutter build apk --release --dart-define-from-file=env/env.prd.json
-```
-
 ## 🛠 Technologies
 
 - [Flutter](https://flutter.dev/)
-- [Firebase](https://firebase.google.com/) (Auth, Firestore)
-- [Provider](https://pub.dev/packages/provider) (State Management)
-- [flutter_native_splash](https://pub.dev/packages/flutter_native_splash)
 - [Firebase CLI](https://firebase.google.com/docs/cli)
+- [Firebase](https://firebase.google.com/) (Auth, Firestore)
+- [Provider](https://pub.dev/packages/provider)
 
 ## 📂 Project Structure
 ```bash
@@ -63,7 +47,17 @@ lib/
 └── validators/      # Input validators and schemas
 ```
 
-## ENV Structure
+## 📦 Installation
+```bash
+git clone https://github.com/DanielArndt0/Talkio.git
+cd talkio
+flutter pub get
+flutter run --dart-define-from-file=env/env.local.json
+```
+⚠️ Make sure to include your Firebase **google-services.json** in **android/app/**
+and your environment config in **env/env.local.json.**
+
+## env.local.json Structure
 ```json
 {
   "androidApiKey": "androidApiKey",
@@ -75,6 +69,11 @@ lib/
   "storageBucket": "storageBucket",
   "messagingSenderId": "messagingSenderId"
 }
+```
+
+## 🧪 Build
+```bash
+flutter build apk --release --dart-define-from-file=env/env.local.json
 ```
 ---
 
@@ -105,6 +104,22 @@ To generate your app’s debug and release certificate fingerprints (SHA-1 and S
 ./gradlew signingReport
 ```
 
+---
+
+## 🧰 Versions
+
+| Tool              | Version         |
+|-------------------|-----------------|
+| **Flutter**       | 3.29.2 stable       |
+| **Dart**          | 3.7.2 stable       |
+| **Java**          | 11        |
+| **Android SDK**   | 35           |
+| **targetSdkVersion** | 35          |
+| **minSdkVersion** | 21              |
+| **Android NDK**   | 27.0.12077973           |
+| **Gradle**        | 8.10.2          |
+| **Kotlin**        | 1.9.24           |
+| **Groovy**        | 3.0.22           |
 ---
 
 ## ✨ Author

--- a/lib/controllers/HomeController.dart
+++ b/lib/controllers/HomeController.dart
@@ -16,6 +16,7 @@ abstract class HomeController {
   void searchBarOnSubmitted(String text);
   Future<void> removeContact({required String contactEmail});
   Future<void> onChatCardTap({required ChatModel chatData});
+  Future<void> onChatCardLongPress({required ChatModel chatData});
   void cancelRemoveContact();
   Future<void> onContactCardTap({required UserModel contact});
   Future<void> sendAddContactForm();

--- a/lib/controllers/impl/HomeControllerImpl.dart
+++ b/lib/controllers/impl/HomeControllerImpl.dart
@@ -70,8 +70,9 @@ class HomeControllerImpl implements HomeController {
           userID: authService.currentUser.uid,
         );
         navigationController.showSnackbar(
-            message:
-                '${addContactName.text} has been added to your contact list!');
+          message:
+              '${addContactName.text} has been added to your contact list!',
+        );
       }
     } on CloudException catch (error) {
       navigationController.showSnackbar(message: error.message);
@@ -125,12 +126,10 @@ class HomeControllerImpl implements HomeController {
   Future<UserModel> getContact({required String contactId}) async {
     try {
       final contact = await cloudDbService.getContactById(
-          userId: authService.currentUser.uid, contactId: contactId);
-      return UserModel(
-        id: contactId,
-        name: contact.name,
-        email: contact.name,
+        userId: authService.currentUser.uid,
+        contactId: contactId,
       );
+      return UserModel(id: contactId, name: contact.name, email: contact.name);
     } catch (error) {
       final contactUser = await cloudDbService.getUserById(userId: contactId);
       return UserModel(
@@ -158,7 +157,23 @@ class HomeControllerImpl implements HomeController {
   }
 
   @override
-  Stream<List<UserModel>> loadContactsByChats(List<ChatCardModel> chats, String currentUserId) {
+  Stream<List<UserModel>> loadContactsByChats(
+    List<ChatCardModel> chats,
+    String currentUserId,
+  ) {
     return cloudDbService.loadContactsByChats(chats, currentUserId);
+  }
+
+  @override
+  Future<void> onChatCardLongPress({required ChatModel chatData}) async {
+    try {
+      await cloudDbService.deleteChat(chatId: chatData.chatData.id);
+    } on CloudException catch (error) {
+      navigationController.showSnackbar(message: error.message);
+    } catch (error) {
+      navigationController.showSnackbar(message: error.toString());
+    } finally {
+      navigationController.pop();
+    }
   }
 }

--- a/lib/modals/DeleteChatModal.dart
+++ b/lib/modals/DeleteChatModal.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:talkio/app/AppColors.dart';
+import 'package:talkio/controllers/HomeController.dart';
+import 'package:talkio/models/ChatModel.dart';
+
+class DeleteChatModal extends StatelessWidget {
+  final HomeController controller;
+  final ChatModel chat;
+  const DeleteChatModal({
+    super.key,
+    required this.controller,
+    required this.chat,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      actionsAlignment: MainAxisAlignment.spaceBetween,
+      title: const Text(
+        'Do you want to remove this chat?',
+      ),
+      actions: [
+        ElevatedButton(
+          onPressed: () => controller.onChatCardLongPress(chatData: chat),
+          style: ElevatedButton.styleFrom(
+            backgroundColor: AppColors.primaryMaterialColor,
+          ),
+          child: const Text(
+            'Remove',
+            style: TextStyle(
+              color: Colors.white,
+            ),
+          ),
+        ),
+        TextButton(
+          onPressed: controller.cancelRemoveContact,
+          child: const Text('Cancel'),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
This pull request introduces the ability to **delete entire chat conversations** in Talkio. Users can now remove chat threads permanently, improving control over their message history.

#### ✅ Changes
- Added support to delete chat documents from Firestore.
- Removed associated messages when a chat is deleted.
- Updated UI to include a delete option in chat actions/modal.
- Handled edge cases (e.g., trying to delete non-existing chats).

#### 🧪 Testing
- [x] Chat is removed for both users.
- [x] All messages within the chat are deleted.
- [x] UI updates immediately after deletion.